### PR TITLE
Fix docker for use in ipld-eth-server CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ To build the application locally, do the following:
 3.  Utilize the `./wrapper.sh` to start the application. An example start-up command might look like the following:
 
     ```bash
-    ./wrapper.sh \
+    VULCANIZE_REPO_BASE_DIR=/path-to-vulcanize-repos ./wrapper.sh \
       -e remote \
       -d ../docker/local/docker-compose-db.yml \
       -d ../docker/local/docker-compose-go-ethereum.yml \

--- a/config.sh
+++ b/config.sh
@@ -2,13 +2,19 @@
 # This "script" is simply a configuration file that will be loaded by other files.
 # It allows users to specify where related directories are instead of having to hardcode them.
 
-vulcanize_ops=/Users/abdulrabbani/GitHub/cerc/ops
-vulcanize_foundry_test=/Users/abdulrabbani/GitHub/cerc/foundry-test
-vulcanize_ipld_eth_db=/Users/abdulrabbani/GitHub/cerc/ipld-eth-db
-vulcanize_ipld_ethcl_indexer=/Users/abdulrabbani/GitHub/cerc/ipld-ethcl-indexer/
-vulcanize_go_ethereum=/Users/abdulrabbani/GitHub/cerc/forks/go-ethereum-cerc/
+vulcanize_repo_base_dir=${VULCANIZE_REPO_BASE_DIR:-"~/vulcanize"}
+
+vulcanize_ops=${vulcanize_repo_base_dir}/ops
+vulcanize_foundry_test=${vulcanize_repo_base_dir}/foundry-test
+vulcanize_ipld_eth_db=${vulcanize_repo_base_dir}/ipld-eth-db
+vulcanize_ipld_ethcl_indexer=${vulcanize_repo_base_dir}/ipld-ethcl-indexer/
+vulcanize_go_ethereum=${vulcanize_repo_base_dir}/go-ethereum/
+vulcanize_ipld_eth_server=${vulcanize_repo_base_dir}/ipld-eth-server/
 
 extra_args="--metrics --metrics.expensive --metrics.addr 0.0.0.0 --metrics.port 6060"
+db_write=true
 eth_forward_eth_calls=false
 eth_proxy_on_error=false
 eth_http_path=""
+watched_addres_gap_filler_enabled=false
+watched_addres_gap_filler_interval=5

--- a/docker/local/docker-compose-go-ethereum.yml
+++ b/docker/local/docker-compose-go-ethereum.yml
@@ -14,7 +14,7 @@ services:
       DB_HOST: ipld-eth-db
       DB_PORT: 5432
       DB_PASSWORD: password
-      DB_WRITE: "true"
+      DB_WRITE: ${db_write}
       DB_TYPE: postgres
       DB_DRIVER: sqlx
       DB_WAIT_FOR_SYNC: "true"

--- a/docker/local/docker-compose-ipld-eth-server.yml
+++ b/docker/local/docker-compose-ipld-eth-server.yml
@@ -3,7 +3,7 @@ services:
   ipld-eth-server:
     restart: unless-stopped
     build:
-      context: ${vulcanize_ipld_eth_db}
+      context: ${vulcanize_ipld_eth_server}
       dockerfile: ./Dockerfile
     environment:
       IPLD_SERVER_GRAPHQL: "true"
@@ -20,6 +20,8 @@ services:
       ETH_FORWARD_ETH_CALLS: $eth_forward_eth_calls
       ETH_PROXY_ON_ERROR: $eth_proxy_on_error
       ETH_HTTP_PATH: $eth_http_path
+      WATCHED_ADDRESS_GAP_FILLER_ENABLED: $watched_addres_gap_filler_enabled
+      WATCHED_ADDRESS_GAP_FILLER_INTERVAL: $watched_addres_gap_filler_interval
     volumes:
       - type: bind
         source: ../../start-up-files/ipld-eth-server/chain.json
@@ -27,15 +29,27 @@ services:
     ports:
       - "127.0.0.1:8081:8081"
 
+  contract:
+    depends_on:
+      - go-ethereum
+    build:
+      context: ${vulcanize_ipld_eth_server}test/contract
+      args:
+        ETH_ADDR: "http://go-ethereum:8545"
+    environment:
+      ETH_ADDR: "http://go-ethereum:8545"
+    ports:
+      - "127.0.0.1:3000:3000"
+
   graphql:
     restart: unless-stopped
     depends_on:
       - ipld-eth-db
     image: vulcanize/postgraphile:v1.0.1
     environment:
-      - PG_HOST=db
+      - PG_HOST=ipld-eth-db
       - PG_PORT=5432
-      - PG_DATABASE=vulcanize_public
+      - PG_DATABASE=vulcanize_testing
       - PG_USER=vdbm
       - PG_PASSWORD=password
       - SCHEMA=public,eth


### PR DESCRIPTION
Part of https://github.com/vulcanize/go-ethereum/issues/127

- Update ipld-eth-server config params.
- Add contract service to use in ipld-eth-server integration tests.