### PR TITLE
Move contract service to a separate docker compose file

### DIFF
--- a/docker/local/docker-compose-contract.yml
+++ b/docker/local/docker-compose-contract.yml
@@ -1,0 +1,13 @@
+version: "3.2"
+services:
+  contract:
+    depends_on:
+      - go-ethereum
+    build:
+      context: ${vulcanize_test_contract}
+      args:
+        ETH_ADDR: "http://go-ethereum:8545"
+    environment:
+      ETH_ADDR: "http://go-ethereum:8545"
+    ports:
+      - "127.0.0.1:3000:3000"

--- a/docker/local/docker-compose-ipld-eth-server.yml
+++ b/docker/local/docker-compose-ipld-eth-server.yml
@@ -29,18 +29,6 @@ services:
     ports:
       - "127.0.0.1:8081:8081"
 
-  contract:
-    depends_on:
-      - go-ethereum
-    build:
-      context: ${vulcanize_ipld_eth_server}/test/contract
-      args:
-        ETH_ADDR: "http://go-ethereum:8545"
-    environment:
-      ETH_ADDR: "http://go-ethereum:8545"
-    ports:
-      - "127.0.0.1:3000:3000"
-
   graphql:
     restart: unless-stopped
     depends_on:


### PR DESCRIPTION
Part of https://github.com/vulcanize/ipld-eth-db-validator/issues/3

- Move `contract` service to a separate docker compose file so that it can be used without `ipld-eth-server`