### PR TITLE
Use nc instead of pg_isready

### DIFF
--- a/docker/latest/docker-compose-db-sharding.yml
+++ b/docker/latest/docker-compose-db-sharding.yml
@@ -23,7 +23,7 @@ services:
       POSTGRES_DB: "vulcanize_testing"
       POSTGRES_PASSWORD: "password"
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready"]
+      test: ["CMD", "nc", "-v", "localhost", "5432"]
       interval: 5s
       timeout: 3s
       retries: 5

--- a/docker/latest/docker-compose-db.yml
+++ b/docker/latest/docker-compose-db.yml
@@ -8,7 +8,7 @@ services:
       POSTGRES_DB: "vulcanize_testing"
       POSTGRES_PASSWORD: "password"
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready"]
+      test: ["CMD", "nc", "-v", "localhost", "5432"]
       interval: 5s
       timeout: 3s
       retries: 5

--- a/docker/local/docker-compose-db-sharding.yml
+++ b/docker/local/docker-compose-db-sharding.yml
@@ -24,8 +24,7 @@ services:
       POSTGRES_DB: "vulcanize_testing"
       POSTGRES_PASSWORD: "password"
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready"]
-      # test: ["CMD", "nc", "-v", "localhost", "5432"]
+      test: ["CMD", "nc", "-v", "localhost", "5432"]
       interval: 5s
       timeout: 3s
       retries: 5

--- a/docker/local/docker-compose-db.yml
+++ b/docker/local/docker-compose-db.yml
@@ -11,7 +11,7 @@ services:
     ports:
       - "127.0.0.1:8077:5432"
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready"]
+      test: ["CMD", "nc", "-v", "localhost", "5432"]
       interval: 5s
       timeout: 3s
       retries: 5


### PR DESCRIPTION
pg_isready outputs an error to console.

```bash
ipld-eth-db_1  | 2022-06-13 18:46:53.973 UTC [67] FATAL:  role "root" does not exist
```

This avoids the output.