### PR TITLE
36 add arm documentation to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ If you want to quickly get all the applications mentioned above cloned and runni
 6.  Build the entire stack.
 
     - For building part of the stack.
+
       ```bash
       ./wrapper.sh -e docker \
         -d ../docker/latest/docker-compose-db.yml \
@@ -97,9 +98,11 @@ If you want to quickly get all the applications mentioned above cloned and runni
         -p ../config.sh
 
       ```
+
       Remove lines for the parts of the stack you don’t want to build.
 
     - For building full stack with specified DB version (v3 or v4)
+
       ```bash
       ./wrapper.sh -f true \
         -s v4 \
@@ -202,4 +205,35 @@ Users might notice issues when attempting to build `ipld-eth-server`. If you are
 
 ```
 sudo su -c "setenforce 0"
+```
+
+## GETH Issues With M1 Macs
+
+Users might notice issues when attempting to build `go-ethereum` on M1 Macs. If this happens, you will either need to manually install `geth` in your `helper-scripts` directory OR run `./wrapper.sh` using the `-e remote` flag to build the stack on a remote server:
+
+### Manually Installing GETH
+
+```
+cd helper-scripts
+wget https://github.com/vulcanize/go-ethereum/releases/download/v1.10.19-statediff-4.0.3-alpha/geth-linux-amd64
+```
+
+Then rename it using:
+
+```
+mv geth-linux-amd64.1 geth-linux-amd64
+```
+
+### Building the Stack on a Remote Server
+
+```
+./wrapper.sh \
+  -e remote \
+  -u <USERNAME> \
+  -n <HOSTNAME> \
+  -d "../docker/latest/docker-compose-db-sharding.yml" \
+  -d "../docker/local/docker-compose-go-ethereum.yml" \
+  -d "../docker/local/docker-compose-contract.yml" \
+  -v remove \
+  -p ../config.sh
 ```

--- a/docker/local/docker-compose-go-ethereum.yml
+++ b/docker/local/docker-compose-go-ethereum.yml
@@ -15,7 +15,7 @@ services:
       test: ["CMD", "nc", "-v", "localhost", "8545"]
       interval: 30s
       timeout: 3s
-      retries: 5
+      retries: 10
     environment:
       DB_USER: vdbm
       DB_NAME: vulcanize_testing

--- a/helper-scripts/compile-geth.sh
+++ b/helper-scripts/compile-geth.sh
@@ -77,7 +77,7 @@ fi
 
 if [[ "$e" = "docker" ]] ; then
     echo -e "${GREEN}Building geth using docker!${NC}"
-    docker build -t vulcanize/go-ethereum -f Dockerfile .
+    docker build --platform linux/arm64 -t vulcanize/go-ethereum -f Dockerfile .
     docker run --rm --entrypoint cat vulcanize/go-ethereum /usr/local/bin/geth > ./geth-linux-amd64
     chmod +x ./geth-linux-amd64
     mv ./geth-linux-amd64 ${start_path}/geth-linux-amd64

--- a/helper-scripts/compile-geth.sh
+++ b/helper-scripts/compile-geth.sh
@@ -77,7 +77,7 @@ fi
 
 if [[ "$e" = "docker" ]] ; then
     echo -e "${GREEN}Building geth using docker!${NC}"
-    docker build --platform linux/arm64 -t vulcanize/go-ethereum -f Dockerfile .
+    docker build -t vulcanize/go-ethereum -f Dockerfile .
     docker run --rm --entrypoint cat vulcanize/go-ethereum /usr/local/bin/geth > ./geth-linux-amd64
     chmod +x ./geth-linux-amd64
     mv ./geth-linux-amd64 ${start_path}/geth-linux-amd64

--- a/helper-scripts/wrapper.sh
+++ b/helper-scripts/wrapper.sh
@@ -36,7 +36,7 @@ exit 1
 # EOF is found above and hence cat command stops reading. This is equivalent to echo but much neater when printing out.
 }
 
-e="local"
+e="docker"
 v="keep"
 u="abdul"
 n="alabaster.vdb.to"
@@ -106,7 +106,6 @@ echo -e "${GREEN} p=${p} ${NC}"
 echo -e "${GREEN} p=${p} ${NC}"
 
 if [ "$f" == "true" ]; then
-    e="docker"
     latestPath="../docker/latest"
     localPath="../docker/local"
     if [ "$l" == "local" ]; then

--- a/start-up-files/go-ethereum/start-private-network.sh
+++ b/start-up-files/go-ethereum/start-private-network.sh
@@ -11,9 +11,12 @@ mkdir -p $ETHDIR
 /bin/bash deploy-local-network.sh --rpc-addr 0.0.0.0 --db-user $DB_USER --db-password $DB_PASSWORD --db-name $DB_NAME \
   --db-host $DB_HOST --db-port $DB_PORT --db-write $DB_WRITE --dir "$ETHDIR" --address $ADDRESS \
   --db-type $DB_TYPE --db-driver $DB_DRIVER --db-waitforsync $DB_WAIT_FOR_SYNC --chain-id $CHAIN_ID --extra-args "$EXTRA_START_ARGS" &
-echo "sleeping 30 sec"
+
 # give it a few secs to start up
-sleep 30
+COUNT=0
+ATTEMPTS=15
+until $(nc -v localhost 8545) || [[ $COUNT -eq $ATTEMPTS ]]; do echo -e "$(( COUNT++ ))... \c"; sleep 10; done
+[[ $COUNT -eq $ATTEMPTS ]] && echo "Could not connect to localhost 8545" && (exit 1)
 
 # Run tests
 cd stateful


### PR DESCRIPTION
# Description

We came across issues building `go-ethereum` when using an M1 Mac(due to difference between the amd/arm architectures). This PR includes some minor code updates, as well as documentation updates for users experiencing the same issues.

- Update `README.md` to outline the necessary steps to take if users experience issues building `go-ethereum` on M1 Macs
- Update the number of retries from `5`->`10` in `docker-compose-go-ethereum.yml`
- Explicitly set the `--platform` to `linux/arm64` in the `compile-geth.sh` script(I'm not actually sure if we still need this step here)
- Default the `wrapper.sh` script to use `-e docker` instead of `-e local`
- Update the `sleep` logic in the `start-private-network.sh` script to attempt to connect to `localhost:8545` every `10` seconds up to a total of `150` seconds, rather than simply sleeping for `30` seconds before attempting to connect

## Link to issue

https://github.com/vulcanize/stack-orchestrator/issues/36

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Refactor (non-breaking change that updates existing functionality)
- [x] Documentation update (updates to README files or comments)
